### PR TITLE
Fix FMPC 2D: restore soft constraint handling and document flat-transform indices

### DIFF
--- a/safe_control_gym/controllers/mpc/fmpc.py
+++ b/safe_control_gym/controllers/mpc/fmpc.py
@@ -316,9 +316,16 @@ class FlatMPC(BaseController):
         z_horizon = self.mpc.x_prev #8xN set in linearMPC
         v_horizon = self.mpc.u_prev #2xN
 
-        # flat input transformation: z and v to action u
-        # Note: using z_horizon[:,0] yeilds really poor performance.
-        # Note: using the feedforward v_horizon[:,1] works slightly better than v_horizon[:,0]
+        # Flat input transformation: z and v to action u.
+        # Always use z_horizon[:,1] (one-step prediction), never z_horizon[:,0]: stage 0 is
+        # hard-constrained to the observed state, so z_0 feeds the raw state estimate straight
+        # back through the transform and the loop diverges (verified: crashes at all speeds).
+        # The v index differs by model because of who estimates the flat state:
+        # - 3D delay model: flat state comes directly from measurement + previous action (no
+        #   observer), so the time-consistent pair (z_1, v_1) is safe and tracks slightly better.
+        # - 2D / 3D_10: the FlatStateObserver reconstructs u_dot assuming the applied action
+        #   belongs to v_0's interval; pairing z_1 with v_1 adds a one-step feedforward lead
+        #   that breaks that bookkeeping (verified: crashes at 9/11 s, ~70x error at 15 s).
         if self.QUAD_TYPE == QuadType.THREE_D_ATTITUDE_DELAY:
             action = self.action_from_flat_states_func(z_horizon[:, 1], v_horizon[:, 1], self.inertial_prop, g=self.mpc.env.GRAVITY_ACC)
             action[0] = np.clip(action[0], 0.08, 0.45)

--- a/safe_control_gym/controllers/mpc/linear_mpc_acados.py
+++ b/safe_control_gym/controllers/mpc/linear_mpc_acados.py
@@ -199,8 +199,27 @@ class LinearMPC_ACADOS(MPC_ACADOS):
         #     else:
         #         raise ValueError('Constraint type not supported. Support only for BoundedConstraint and descendants. Check constraints.py.')
 
+        # slack costs for nonlinear constraints (same treatment as MPC_ACADOS)
         if self.soft_constraints:
-            print(colored('Linear MPC soft constraints not implemented yet.', 'yellow'))
+            # slack variables for all constraints
+            ocp.constraints.Jsh_0 = np.eye(h0_expr.shape[0])
+            ocp.constraints.Jsh = np.eye(h_expr.shape[0])
+            ocp.constraints.Jsh_e = np.eye(he_expr.shape[0])
+            # slack penalty
+            L2_pen = self.soft_penalty
+            L1_pen = self.soft_penalty
+            ocp.cost.Zl_0 = L2_pen * np.ones(h0_expr.shape[0])
+            ocp.cost.Zu_0 = L2_pen * np.ones(h0_expr.shape[0])
+            ocp.cost.zl_0 = L1_pen * np.ones(h0_expr.shape[0])
+            ocp.cost.zu_0 = L1_pen * np.ones(h0_expr.shape[0])
+            ocp.cost.Zu = L2_pen * np.ones(h_expr.shape[0])
+            ocp.cost.Zl = L2_pen * np.ones(h_expr.shape[0])
+            ocp.cost.zl = L1_pen * np.ones(h_expr.shape[0])
+            ocp.cost.zu = L1_pen * np.ones(h_expr.shape[0])
+            ocp.cost.Zl_e = L2_pen * np.ones(he_expr.shape[0])
+            ocp.cost.Zu_e = L2_pen * np.ones(he_expr.shape[0])
+            ocp.cost.zl_e = L1_pen * np.ones(he_expr.shape[0])
+            ocp.cost.zu_e = L1_pen * np.ones(he_expr.shape[0])
 
         # placeholder initial state constraint
         x_init = np.zeros((nx))


### PR DESCRIPTION
## Summary

Two FMPC fixes for the `benchmark` branch:

- **Restore soft-constraint handling in `LinearMPC_ACADOS`** — the Sep 2025 rewrite of
  `setup_acados_optimizer` (22b5d0bd) dropped the parent's slack-variable treatment, so
  `soft_constraints=True` silently became hard constraints. FMPC's acceleration box
  constraints (thrust-limit proxy) made every HPIPM solve fail, crashing FMPC 2D on the
  figure8 task (0.53 m RMSE, out of bounds in ~1 s). With the slack block restored:
  660/660 steps, 7.5 mm RMSE, zero QP errors.
- **Document the flat-transform index choices in `fmpc.py`** — replaces the terse notes
  with why `z_1` is mandatory (closing the loop on `z_0` diverges) and why `v_1` is correct
  only for the observer-less 3D delay model while `v_0` must stay for the observer-based
  2D/3D_10 models, backed by 10-seed index sweeps (each wrong pairing crashes or degrades
  ~70x).

## Testing

- FMPC 2D figure8 (`mb_experiment.py fmpc`): 660/660 steps, RMSE 0.0075 m, 0 QP errors
  (before the fix: crashes out of bounds at step ~55 with HPIPM status-3 failures on every
  solve)
- Full FMPC benchmark sweep (10 seeds: generalization 9-15 s, obs/proc-noise sweeps,
  parametric robustness): no failures in nominal conditions, 11 s tracking at 8.5 +/- 0.7 mm
- Index-pairing sweeps supporting the documented claims: (z_0, v_0) and (z_1, v_1) both
  fail on the 2D model at all/most trajectory speeds

Note: the soft-constraint slack block activates for any controller constructed with
`soft_constraints=True`; FMPC is currently the only benchmark config that sets it, so other
controllers' results are unaffected.
